### PR TITLE
Set API documentation for common errors in a global way

### DIFF
--- a/fizzbuzz/src/main/java/de/gamue/OpenApiConfig.java
+++ b/fizzbuzz/src/main/java/de/gamue/OpenApiConfig.java
@@ -1,9 +1,20 @@
 package de.gamue;
 
+import de.gamue.fizzbuzz.ErrorResponse;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.SpringDocAnnotationsUtils;
+import org.springdoc.core.customizers.OpenApiCustomiser;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 
 @Configuration
@@ -18,4 +29,27 @@ public class OpenApiConfig {
                         .version("1.0"));
     }
 
+    @Bean
+    public OpenApiCustomiser customerGlobalHeaderOpenApiCustomiser(OpenAPI api) {
+        return openApi -> {
+            openApi.getPaths().values().forEach(pathItem -> pathItem.readOperations().forEach(operation -> {
+                ApiResponses apiResponses = operation.getResponses();
+                ApiResponse badRequestError = getErrorResponse("Bad Request", api);
+                apiResponses.addApiResponse(String.valueOf(HttpStatus.BAD_REQUEST.value()), badRequestError);
+            }));
+        };
+    }
+
+    private ApiResponse getErrorResponse(String description, OpenAPI api){
+        Schema errorResponseSchema = SpringDocAnnotationsUtils.extractSchema(
+                api.getComponents(),
+                ErrorResponse.class,
+                null,
+                null
+        );
+        MediaType mediaType = new MediaType().schema(errorResponseSchema);
+        return new ApiResponse()
+                .description(description)
+                .content(new Content().addMediaType(APPLICATION_JSON_VALUE, mediaType));
+    }
 }

--- a/fizzbuzz/src/main/java/de/gamue/fizzbuzz/ErrorResponse.java
+++ b/fizzbuzz/src/main/java/de/gamue/fizzbuzz/ErrorResponse.java
@@ -1,0 +1,17 @@
+package de.gamue.fizzbuzz;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class ErrorResponse {
+
+    @Schema(description = "the error message", example = "value is lower than 1.")
+    String message;
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/fizzbuzz/src/main/java/de/gamue/fizzbuzz/FizzBuzzController.java
+++ b/fizzbuzz/src/main/java/de/gamue/fizzbuzz/FizzBuzzController.java
@@ -29,6 +29,9 @@ public class FizzBuzzController {
 
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseStatus(value = HttpStatus.BAD_REQUEST)
-    public void handleException(IllegalArgumentException e){
+    public ErrorResponse handleException(IllegalArgumentException e){
+        ErrorResponse response = new ErrorResponse();
+        response.setMessage(e.getMessage());
+        return response;
     }
 }


### PR DESCRIPTION
- Define general API-Responses inside code to reduce duplication